### PR TITLE
Fix make unittest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ nfd_win.obj: $(NFD)/nfd_win.cpp $(NFD)/include/nfd.h
 	$(CC) -c -I$(NFD)/include $(CFLAGS) $< -o $@
 
 unittest: $(src) default.fnt
-	$(DC) $(src) -g -debug -unittest -J. -of$@ && ./$@
+	$(DC) $(src) -g --d-debug -unittest -J. -of$@ && ./$@
 
 clean:
 	rm -f xtmc unittest xtmc.o unittest.o


### PR DESCRIPTION
    ldc2.exe: Unknown command line argument '-debug'.  Try: 'C:\bin\ldc\bin\ldc2.exe --help'
    ldc2.exe: Did you mean '--d-debug'?

Now it's:

    tmc.d(554): Error: file `"pongbl.tmc"` cannot be found or not in a path specified with `-J`
    tmc.d(554):        Path(s) searched (as provided by `-J`):
    tmc.d(554):        [0]: `.`

You should probably `git add` it.